### PR TITLE
Added support for Symfony 3.2

### DIFF
--- a/TwigJs/Compiler/TransFilterCompiler.php
+++ b/TwigJs/Compiler/TransFilterCompiler.php
@@ -2,7 +2,6 @@
 
 namespace JMS\TwigJsBundle\TwigJs\Compiler;
 
-use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
 use TwigJs\FilterCompilerInterface;
 use TwigJs\JsCompiler;
@@ -45,7 +44,7 @@ class TransFilterCompiler implements FilterCompilerInterface
      */
     public function compile(JsCompiler $compiler, \Twig_Node_Expression_Filter $node)
     {
-        if (!($locale = $compiler->getDefine('locale')) || !$this->translator instanceof Translator) {
+        if (!($locale = $compiler->getDefine('locale')) || !$this->translator instanceof TranslatorInterface) {
             return false;
         }
 

--- a/TwigJs/Compiler/TransFilterCompiler.php
+++ b/TwigJs/Compiler/TransFilterCompiler.php
@@ -2,6 +2,7 @@
 
 namespace JMS\TwigJsBundle\TwigJs\Compiler;
 
+use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
 use TwigJs\FilterCompilerInterface;
 use TwigJs\JsCompiler;
@@ -44,7 +45,7 @@ class TransFilterCompiler implements FilterCompilerInterface
      */
     public function compile(JsCompiler $compiler, \Twig_Node_Expression_Filter $node)
     {
-        if (!($locale = $compiler->getDefine('locale')) || !$this->translator instanceof TranslatorInterface) {
+        if (!($locale = $compiler->getDefine('locale')) || !$this->translator instanceof Translator) {
             return false;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "forknetwork/twig-js": "^2.0.1",
         "symfony/config": "~2.1|~3.0",
         "symfony/dependency-injection": "~2.1|~3.0",
+        "symfony/framework-bundle": "~2.1|~3.0",
         "symfony/http-foundation": "~2.1|~3.0",
         "symfony/http-kernel": "~2.1|~3.0",
         "symfony/translation": "~2.1|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
     "require": {
         "php": ">=5.3.2",
         "forknetwork/twig-js": "^2.0.1",
-        "symfony/framework-bundle": "~2.1|~3.0",
+        "symfony/config": "~2.1|~3.0",
+        "symfony/dependency-injection": "~2.1|~3.0",
+        "symfony/http-foundation": "~2.1|~3.0",
+        "symfony/http-kernel": "~2.1|~3.0",
+        "symfony/translation": "~2.1|~3.0",
         "symfony/twig-bridge": "~2.1|~3.0"
     },
     "replace": {


### PR DESCRIPTION
The dependency requirements of the Symfony FrameworkBundle has been updated. They removed some components this bundle was leaning on. I've added all of these components to the requirements of this bundle.