### PR TITLE
PHP 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
     - php: 5.6
       env: SYMFONY_VERSION=3.1.* COVERAGE=true
-  allow_failures:
-    - php: 7.0
-    - php: 7.1
 
 cache:
   directories:


### PR DESCRIPTION
We should not have PHP 7 as allowed failures. The project should be able to run on PHP 7.0 and PHP 7.1.