### PR TITLE
Updated Twig.js to 4.0+ and Twig to 2.7+.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ sudo: false
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 matrix:
   fast_finish: true
   include:
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.2
+    - php: 7.3
       env: SYMFONY_VERSION=3.1.* COVERAGE=true
 
 cache:

--- a/Tests/TwigJs/Compiler/BaseTestCase.php
+++ b/Tests/TwigJs/Compiler/BaseTestCase.php
@@ -3,12 +3,15 @@
 namespace JMS\TwigJsBundle\Tests\TwigJs\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Source;
 use TwigJs\JsCompiler;
 
 abstract class BaseTestCase extends TestCase
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     protected $env;
 
@@ -20,11 +23,11 @@ abstract class BaseTestCase extends TestCase
     /**
      * @param string $string
      * @return string
-     * @throws \Twig_Error_Syntax
+     * @throws \Twig\Error\SyntaxError
      */
     protected function compile($string)
     {
-        $twigSource = new \Twig_Source($string, md5($string));
+        $twigSource = new Source($string, md5($string));
 
         return $this->env->compileSource($twigSource);
     }
@@ -34,7 +37,7 @@ abstract class BaseTestCase extends TestCase
      */
     protected function setUp()
     {
-        $this->env = $env = new \Twig_Environment(new \Twig_Loader_Array());
+        $this->env = $env = new Environment(new ArrayLoader());
         $env->setCompiler($this->compiler = new JsCompiler($env));
     }
 }

--- a/TwigJs/Compiler/TransFilterCompiler.php
+++ b/TwigJs/Compiler/TransFilterCompiler.php
@@ -4,6 +4,7 @@ namespace JMS\TwigJsBundle\TwigJs\Compiler;
 
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Node\Expression\FilterExpression;
 use TwigJs\FilterCompilerInterface;
 use TwigJs\JsCompiler;
 
@@ -43,7 +44,7 @@ class TransFilterCompiler implements FilterCompilerInterface
     /**
      * {@inheritdoc}
      */
-    public function compile(JsCompiler $compiler, \Twig_Node_Expression_Filter $node)
+    public function compile(JsCompiler $compiler, FilterExpression $node)
     {
         if (!($locale = $compiler->getDefine('locale')) || !$this->translator instanceof Translator) {
             return false;
@@ -59,7 +60,7 @@ class TransFilterCompiler implements FilterCompilerInterface
         // ignore dynamic messages, we cannot resolve these
         // users can still apply a runtime trans filter to do this
         $subNode = $node->getNode('node');
-        if (!$subNode instanceof \Twig_Node_Expression_Constant) {
+        if (!$subNode instanceof \Twig\Node\Expression\ConstantExpression) {
             return false;
         }
 
@@ -74,7 +75,7 @@ class TransFilterCompiler implements FilterCompilerInterface
             if ($arguments->hasNode(1)) {
                 $domainNode = $arguments->getNode(1);
 
-                if (!$domainNode instanceof \Twig_Node_Expression_Constant) {
+                if (!$domainNode instanceof \Twig\Node\Expression\ConstantExpression) {
                     return false;
                 }
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "forknetwork/twig-js": "^3.0.1",
+        "forknetwork/twig-js": "^4.0",
         "symfony/config": "^3.0|^4.0",
         "symfony/dependency-injection": "^3.0|^4.0",
         "symfony/framework-bundle": "^3.0|^4.0",
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "4.0-dev"
         }
     }
 }


### PR DESCRIPTION
Since the release of Twig 2.7 a new namespacing standard has been introduced. This is followed by a new major version of Twig.js. Users should not be affected by the changes unless they are extending from the Twig.js classes.

This pull request also includes PHP 7.3 support for Travis CI.